### PR TITLE
testdev script for testing on operation system

### DIFF
--- a/misc/testdev
+++ b/misc/testdev
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+sudo unshare --ipc --mount bash -c "$(tail -n +5 "$0")" "$0" "$USER" "$@"
+exit $?
+
+# The real script starts here
+U="$1"
+shift
+
+mount --bind /usr2/fs-dev /usr2/fs
+mount --bind /usr2/fs-dev/st.default/control /usr2/control
+mount -t tmpfs tmpfs /var/run/fsserver
+
+/usr2/fs/bin/fsalloc
+[ -f /usr2/st/bin/stalloc ] && /usr2/st/bin/stalloc
+
+sudo -u "$U" -i


### PR DESCRIPTION
This is a preliminary sketch of a utility to assist testing a development
version of the Field System on an operational machine without disturbing
the working system, as discussed in issue #21.

As it stands it is very basic and some experimentation and discussion is needed
to understand the use case(s).

Current assumptions:

-   User has root access via `sudo`
-   FS version to be tested is /usr2/fs-dev
-   st.default control files should be used

Outstanding issues & questions:

- [ ] Should we protect the log directory? We could either mount a tmpfs or overlayfs here?
- [ ] ditto proc
- [ ] ditto control
- [ ] how to handled st code? May need recompiling, so an overlayfs might be the way to go.
- [ ] can this be done without sudo/root access? User namespaces should allow this but I had some quirk that stopped fsalloc from working.