### PR TITLE
Fix `helpstr_` erroing on shell syntax

### DIFF
--- a/clib/helpstr.c
+++ b/clib/helpstr.c
@@ -60,7 +60,7 @@ static char *is_in_dir(char *name, char **dirs) {
 	return NULL;
 }
 
-// check_help_dirs_prefix returns a null terminated list of files that start with
+// ls_prefix returns a null terminated list of files that start with
 // prefix. Returns NULL on error.
 // List and its elements must be released by free.
 static char **ls_prefix(char **dirs, char *prefix) {

--- a/clib/helpstr.c
+++ b/clib/helpstr.c
@@ -99,8 +99,8 @@ static char **ls_prefix(char **dirs, char *prefix) {
 				len += len;
 				ret = realloc(ret, (len + 1) * (sizeof(char *)));
 				size_t i;
-				for (i = len / 2; i <= len; i++) {
-					*ret[i] = 0;
+				for (i = len / 2; i < len + 1; i++) {
+					ret[i] = NULL;
 				}
 			}
 

--- a/clib/helpstr.c
+++ b/clib/helpstr.c
@@ -17,6 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+
 /*  This subroutine finds the correct, if only, help file to list */
 /*  with the help command. It uses the rack and drive variables   */
 /*  passed in by the calling program to match with the extensions */
@@ -26,14 +27,92 @@
 /*  any type of equipment. An m is for Mark III, and a v is for   */
 /*  VLBA.                                                         */
 
+#include <dirent.h>
+#include <limits.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
 #include "../include/params.h"
 
-#define MAX_STRING  256
+#define MAX_STRING 256
 
-void helpstr_(cnam,clength,runstr,rack,drive1,drive2,ierr,clen,rlen)
-char *cnam;
+// fileexists check if file exists and is readable
+static int fileexists(const char *filename) {
+	FILE *file;
+	if ((file = fopen(filename, "r"))) {
+		fclose(file);
+		return 1;
+	}
+	return 0;
+}
+
+static char *help_dirs[] = {FS_ROOT "/st/help", FS_ROOT "/fs/help", NULL};
+
+// check_help_dirs looks for file "name" in help dirs and returns first match as a
+// string.  Resulting string must be released with free
+static char *check_help_dirs(char *name) {
+	char **dir;
+	char *path;
+
+	for (dir = help_dirs; *dir != NULL; dir++) {
+		if (asprintf(&path, "%s/%s", *dir, name) < 0)
+			return NULL;
+		if (fileexists(path)) {
+			return path;
+		}
+		free(path);
+	}
+	return NULL;
+}
+
+// check_help_dirs_prefix returns a null terminated list of files that start with
+// prefix. Returns NULL on error.
+// List and its elements must be released by free.
+static char **ls_prefix(char **dirs, char *prefix) {
+
+	size_t prefix_len = strlen(prefix);
+	if (!prefix_len)
+		return NULL;
+
+	// length of allocated buffer
+	size_t len = 10;
+	char **ret = calloc(len + 1, sizeof(char *));
+	if (!ret)
+		return NULL;
+
+	DIR *dp;
+	struct dirent *ep;
+
+	size_t nmatches = 0;
+	char **d;
+	for (d = dirs; *d != NULL; d++) {
+		dp = opendir(*d);
+		if (dp == NULL)
+			continue;
+		while ((ep = readdir(dp))) {
+			if (strncmp(prefix, ep->d_name, prefix_len) != 0) {
+				continue;
+			}
+
+			nmatches++;
+
+			if (nmatches > len) {
+				len += len;
+				ret = realloc(ret, len + 1);
+			}
+
+			if (asprintf(&ret[nmatches - 1], "%s/%s", *d, ep->d_name) < 0)
+				return NULL;
+		}
+		closedir(dp);
+	}
+	return ret;
+}
+
+void helpstr_(cnam, clength, runstr, rack, drive1, drive2, ierr, clen, rlen) char *cnam;
 int *clength;
 char *runstr;
 int *rack;
@@ -43,115 +122,94 @@ int *ierr;
 int clen;
 int rlen;
 {
-  char string[MAX_STRING+1],*s1;
-  char *decloc, *declocstr;
-  int inum;
-  FILE *idum;
-  int freq,system();
-  int i;
-  char outbuf[80];
-  char equip1, equip2, ch1, ch2, ch3;
+	char name[MAX_STRING] = {};
+	char *decloc;
+	char ch1, ch2, ch3;
 
-  *ierr=0;
-  if (*clength > MAX_STRING) {
-    *ierr=-2;
-    return;
-  }
+	*ierr = -3;
 
-  s1=strncpy(string,cnam,*clength);
-  string[*clength]='\0';
+	if (*clength > MAX_STRING) {
+		*ierr = -2;
+		return;
+	}
 
-  declocstr = strchr(string,'.');
-  if(declocstr==NULL)
-    strcat(string,".*");
+	strncpy(name, cnam, *clength);
+	name[*clength] = '\0';
 
-  strcpy(outbuf,"ls ");
-  strcat(outbuf,FS_ROOT);
-  strcat(outbuf,"/st/help/");
-  strcat(outbuf,string);
+	decloc = strchr(name, '.');
+	if (decloc != NULL) {
+		char *p = check_help_dirs(name);
+		if (p == NULL) {
+			return;
+		}
+		*ierr = 0;
+		strcpy(runstr, p);
+		free(p);
+		return;
+	}
 
-  strcat(outbuf," > /tmp/LS.NUM 2> /dev/null");
+	char **paths = ls_prefix(help_dirs, name);
+	if (!paths) {
+		return;
+	}
 
-  freq = system(outbuf);
+	char **p;
+	for (p = paths; *p != NULL; p++) {
+		char *path = *p;
+		decloc     = strrchr(path, '.');
+		if (decloc == NULL) {
+			continue;
+		}
+		ch1 = *(decloc + 1);
+		ch2 = *(decloc + 2);
+		ch3 = *(decloc + 3);
+		if ((ch1 == '_' || (ch1 == '3' && K4K3 == *rack) || (ch1 == 'm' && MK3 == *rack) ||
+		     (ch1 == 'n' && (MK3 == *rack || MK4 == *rack || LBA4 == *rack)) ||
+		     (ch1 == 'e' && (MK3 == *rack || MK4 == *rack || VLBA == *rack ||
+		                     VLBA4 == *rack || LBA4 == *rack || DBBC == *rack)) ||
+		     (ch1 == 'f' && (MK3 == *rack || MK4 == *rack || K4K3 == *rack ||
+		                     K4MK4 == *rack || K4 == *rack || LBA4 == *rack)) ||
+		     (ch1 == '4' && MK4 == *rack) || (ch1 == 's' && S2 == *rack) ||
+		     (ch1 == 'g' && (MK4 == *rack || VLBA == *rack || VLBA4 == *rack ||
+		                     K4MK4 == *rack || LBA4 == *rack)) ||
+		     (ch1 == 'h' &&
+		      (MK4 == *rack || VLBA4 == *rack || K4MK4 == *rack || LBA4 == *rack)) ||
+		     (ch1 == 'i' &&
+		      (MK4 == *rack || VLBA == *rack || VLBA4 == *rack || K4MK4 == *rack)) ||
+		     (ch1 == 'v' && (VLBA == *rack)) ||
+		     (ch1 == 'w' && (VLBA == *rack || VLBA4 == *rack)) ||
+		     (ch1 == 'k' && (K4K3 == *rack || K4MK4 == *rack || K4 == *rack)) ||
+		     (ch1 == 'l' && (LBA == *rack || LBA4 == *rack)) ||
+		     (ch1 == 'd' && DBBC == *rack) || (ch1 == 'a' && 0 != *rack)) &&
+		    (ch2 == '_' || ch2 == '+' || (ch2 == 'k' && K4 == *drive1) ||
+		     (ch2 == 'm' && MK3 == *drive1) ||
+		     (ch2 == 'n' && (MK3 == *drive1 || MK4 == *drive1)) ||
+		     (ch2 == '4' && MK4 == *drive1) || (ch2 == 's' && S2 == *drive1) ||
+		     (ch2 == 'w' && (VLBA == *drive1 || VLBA4 == *drive1)) ||
+		     (ch2 == 'a' && 0 != *drive1) ||
+		     (ch2 == 'l' &&
+		      (MK3 == *drive1 || MK4 == *drive1 || VLBA == *drive1 || VLBA4 == *drive1))) &&
+		    (ch3 == '_' || ch3 == '+' || (ch3 == 'k' && K4 == *drive2) ||
+		     (ch3 == 'm' && MK3 == *drive2) ||
+		     (ch3 == 'n' && (MK3 == *drive2 || MK4 == *drive2)) ||
+		     (ch3 == '4' && MK4 == *drive2) || (ch3 == 's' && S2 == *drive2) ||
+		     (ch3 == 'w' && (VLBA == *drive2 || VLBA4 == *drive2)) ||
+		     (ch3 == 'a' && 0 != *drive2) ||
+		     (ch3 == 'l' &&
+		      (MK3 == *drive2 || MK4 == *drive2 || VLBA == *drive2 || VLBA4 == *drive2))) &&
+		    ((*drive1 != 0 && *drive2 != 0 &&
+		      ((ch2 == '+' || ch3 == '+') || (ch2 == '_' && ch3 == '_'))) ||
+		     ((*drive1 == 0 || *drive2 == 0) && (ch2 != '+' && ch3 != '+')))) {
+			strcpy(runstr, path);
+			*ierr = 0;
+			goto cleanup;
+		}
+	}
 
-  strcpy(outbuf,"ls ");
-  strcat(outbuf,FS_ROOT);
-  strcat(outbuf,"/fs/help/");
-  strcat(outbuf,string);
+cleanup:
 
-  strcat(outbuf," >> /tmp/LS.NUM 2> /dev/null");
-  freq = system(outbuf);
-
-  idum=fopen("/tmp/LS.NUM","r");
-  unlink("/tmp/LS.NUM");
-  *ierr = -3;
-  while(-1!=fscanf(idum,"%s",outbuf)){
-    decloc = strrchr(outbuf,'.');
-    if(declocstr !=NULL) {
-      strcpy(runstr,outbuf);
-      *ierr = 0;
-      break;
-    } else if(decloc != NULL) {
-      ch1=*(decloc+1);
-      ch2=*(decloc+2);
-      ch3=*(decloc+3);
-      if((ch1== '_' ||
-	  (ch1 == '3' &&  K4K3  == *rack) ||
-	  (ch1 == 'm' &&  MK3   == *rack) ||
-	  (ch1 == 'n' && (MK3   == *rack || MK4   == *rack ||
-	                  LBA4  == *rack)) ||
-	  (ch1 == 'e' && (MK3   == *rack || MK4   == *rack ||
-			  VLBA  == *rack || VLBA4 == *rack ||
-	                  LBA4  == *rack || DBBC  == *rack)) ||
-	  (ch1 == 'f' && (MK3   == *rack || MK4   == *rack ||
-			  K4K3  == *rack || K4MK4 == *rack ||
-			  K4    == *rack || LBA4  == *rack)) ||
-	  (ch1 == '4' &&  MK4   == *rack) ||
-	  (ch1 == 's' &&  S2    == *rack) ||
-	  (ch1 == 'g' && (MK4   == *rack || VLBA  == *rack ||
-			  VLBA4 == *rack || K4MK4 == *rack ||
-			  LBA4  == *rack)) ||
-	  (ch1 == 'h' && (MK4   == *rack || VLBA4 == *rack ||
-			  K4MK4 == *rack || LBA4  == *rack)) ||
-	  (ch1 == 'i' && (MK4   == *rack || VLBA  == *rack ||
-			  VLBA4 == *rack || K4MK4 == *rack)) ||
-	  (ch1 == 'v' && (VLBA  == *rack)) ||
-	  (ch1 == 'w' && (VLBA  == *rack || VLBA4 == *rack)) ||
-	  (ch1 == 'k' && (K4K3  == *rack || K4MK4 == *rack ||
-			  K4    == *rack)) ||
-	  (ch1 == 'l' && (LBA   == *rack || LBA4 == *rack)) ||
-	  (ch1 == 'd' &&  DBBC  == *rack) ||
-	  (ch1 == 'a' &&  0     != *rack)) &&
-	 (ch2 == '_' || ch2 == '+' ||
-	  (ch2 == 'k' &&  K4    == *drive1) ||
-	  (ch2 == 'm' &&  MK3   == *drive1) ||
-	  (ch2 == 'n' && (MK3   == *drive1 || MK4 == *drive1)) ||
-	  (ch2 == '4' &&  MK4   == *drive1) ||
-	  (ch2 == 's' &&  S2    == *drive1) ||
-	  (ch2 == 'w' && (VLBA  == *drive1 || VLBA4 == *drive1)) ||
-	  (ch2 == 'a' &&  0     != *drive1) ||
-	  (ch2 == 'l' && (MK3   == *drive1 || MK4   == *drive1 ||
-			  VLBA  == *drive1 || VLBA4 == *drive1 ))) &&
-	 (ch3 == '_' || ch3 == '+' ||
-	  (ch3 == 'k' &&  K4    == *drive2) ||
-	  (ch3 == 'm' &&  MK3   == *drive2) ||
-	  (ch3 == 'n' && (MK3   == *drive2 || MK4 == *drive2)) ||
-	  (ch3 == '4' &&  MK4   == *drive2) ||
-	  (ch3 == 's' &&  S2    == *drive2) ||
-	  (ch3 == 'w' && (VLBA  == *drive2 || VLBA4 == *drive2)) ||
-	  (ch3 == 'a' &&  0     != *drive2) ||
-	  (ch3 == 'l' && (MK3   == *drive2 || MK4   == *drive2 ||
-			  VLBA  == *drive2 || VLBA4 == *drive2 )))
-	 &&
-	 ((*drive1 !=0 && *drive2 !=0 && ((ch2 == '+' || ch3 == '+') ||
-					  (ch2 =='_' && ch3 == '_'))) ||
-	  ((*drive1 ==0 || *drive2 == 0) && (ch2 != '+' && ch3 != '+')))
-	 ) {
-        strcpy(runstr,outbuf);
-        *ierr = 0;
-        break;
-      }
-    }
-  }
-  fclose(idum);
+	p = paths;
+	while (*p)
+		free(*p++);
+	free(paths);
 }

--- a/clib/helpstr.c
+++ b/clib/helpstr.c
@@ -39,16 +39,6 @@
 
 #define MAX_STRING 256
 
-// fileexists check if file exists and is readable
-static int fileexists(const char *filename) {
-	FILE *file;
-	if ((file = fopen(filename, "r"))) {
-		fclose(file);
-		return 1;
-	}
-	return 0;
-}
-
 static char *help_dirs[] = {FS_ROOT "/st/help", FS_ROOT "/fs/help", NULL};
 
 // check_help_dirs looks for file "name" in help dirs and returns first match as a
@@ -60,7 +50,8 @@ static char *check_help_dirs(char *name) {
 	for (dir = help_dirs; *dir != NULL; dir++) {
 		if (asprintf(&path, "%s/%s", *dir, name) < 0)
 			return NULL;
-		if (fileexists(path)) {
+		}
+		if (access(path, R_OK)) {
 			return path;
 		}
 		free(path);

--- a/clib/helpstr.c
+++ b/clib/helpstr.c
@@ -101,7 +101,11 @@ static char **ls_prefix(char **dirs, char *prefix) {
 
 			if (nmatches > len) {
 				len += len;
-				ret = realloc(ret, len + 1);
+				ret = realloc(ret, (len + 1) * (sizeof(char *)));
+				size_t i;
+				for (i = len / 2; i <= len; i++) {
+					*ret[i] = 0;
+				}
 			}
 
 			if (asprintf(&ret[nmatches - 1], "%s/%s", *d, ep->d_name) < 0)

--- a/clib/helpstr.c
+++ b/clib/helpstr.c
@@ -43,7 +43,7 @@ static char *help_dirs[] = {FS_ROOT "/st/help", FS_ROOT "/fs/help", NULL};
 
 // is_in_dirs looks for file "name" in dirs and returns first match as a
 // string.  Resulting string must be released with free
-static char *is_in_dir(char *name, char **dirs) {
+static char *is_in_dirs(char **dirs, char *name) {
 	char **dir;
 	char *path;
 
@@ -145,7 +145,7 @@ int rlen;
 
 	decloc = strchr(name, '.');
 	if (decloc != NULL) {
-		char *p = is_in_dir(name, help_dirs);
+		char *p = is_in_dirs(help_dirs, name);
 		if (p == NULL) {
 			return;
 		}

--- a/clib/helpstr.c
+++ b/clib/helpstr.c
@@ -48,7 +48,8 @@ static char *check_help_dirs(char *name) {
 	char *path;
 
 	for (dir = help_dirs; *dir != NULL; dir++) {
-		if (asprintf(&path, "%s/%s", *dir, name) < 0)
+		if (asprintf(&path, "%s/%s", *dir, name) < 0) {
+			perror("error during asprintf in check_help_dirs");
 			return NULL;
 		}
 		if (access(path, R_OK)) {
@@ -71,8 +72,10 @@ static char **ls_prefix(char **dirs, char *prefix) {
 	// length of allocated buffer
 	size_t len = 10;
 	char **ret = calloc(len + 1, sizeof(char *));
-	if (!ret)
+	if (!ret) {
+		perror("error calloc asprintf in ls_prefix");
 		return NULL;
+	}
 
 	DIR *dp;
 	struct dirent *ep;
@@ -81,8 +84,10 @@ static char **ls_prefix(char **dirs, char *prefix) {
 	char **d;
 	for (d = dirs; *d != NULL; d++) {
 		dp = opendir(*d);
-		if (dp == NULL)
+		if (dp == NULL) {
+			perror("error opening help directory");
 			continue;
+		}
 		while ((ep = readdir(dp))) {
 			if (strncmp(prefix, ep->d_name, prefix_len) != 0) {
 				continue;
@@ -99,8 +104,10 @@ static char **ls_prefix(char **dirs, char *prefix) {
 				}
 			}
 
-			if (asprintf(&ret[nmatches - 1], "%s/%s", *d, ep->d_name) < 0)
+			if (asprintf(&ret[nmatches - 1], "%s/%s", *d, ep->d_name) < 0) {
+				perror("error during asprintf in ls_prefix");
 				return NULL;
+			}
 		}
 		closedir(dp);
 	}

--- a/clib/helpstr.c
+++ b/clib/helpstr.c
@@ -41,13 +41,13 @@
 
 static char *help_dirs[] = {FS_ROOT "/st/help", FS_ROOT "/fs/help", NULL};
 
-// check_help_dirs looks for file "name" in help dirs and returns first match as a
+// is_in_dirs looks for file "name" in dirs and returns first match as a
 // string.  Resulting string must be released with free
-static char *check_help_dirs(char *name) {
+static char *is_in_dir(char *name, char **dirs) {
 	char **dir;
 	char *path;
 
-	for (dir = help_dirs; *dir != NULL; dir++) {
+	for (dir = dirs; *dir != NULL; dir++) {
 		if (asprintf(&path, "%s/%s", *dir, name) < 0) {
 			perror("error during asprintf in check_help_dirs");
 			return NULL;
@@ -145,7 +145,7 @@ int rlen;
 
 	decloc = strchr(name, '.');
 	if (decloc != NULL) {
-		char *p = check_help_dirs(name);
+		char *p = is_in_dir(name, help_dirs);
 		if (p == NULL) {
 			return;
 		}

--- a/clib/helpstr.c
+++ b/clib/helpstr.c
@@ -112,7 +112,8 @@ static char **ls_prefix(char **dirs, char *prefix) {
 	return ret;
 }
 
-void helpstr_(cnam, clength, runstr, rack, drive1, drive2, ierr, clen, rlen) char *cnam;
+void helpstr_(cnam, clength, runstr, rack, drive1, drive2, ierr, clen, rlen)
+char *cnam;
 int *clength;
 char *runstr;
 int *rack;
@@ -163,13 +164,17 @@ int rlen;
 		ch1 = *(decloc + 1);
 		ch2 = *(decloc + 2);
 		ch3 = *(decloc + 3);
-		if ((ch1 == '_' || (ch1 == '3' && K4K3 == *rack) || (ch1 == 'm' && MK3 == *rack) ||
+		if (
+		    (ch1 == '_' ||
+		     (ch1 == '3' && K4K3 == *rack) ||
+		     (ch1 == 'm' && MK3 == *rack) ||
 		     (ch1 == 'n' && (MK3 == *rack || MK4 == *rack || LBA4 == *rack)) ||
 		     (ch1 == 'e' && (MK3 == *rack || MK4 == *rack || VLBA == *rack ||
 		                     VLBA4 == *rack || LBA4 == *rack || DBBC == *rack)) ||
 		     (ch1 == 'f' && (MK3 == *rack || MK4 == *rack || K4K3 == *rack ||
 		                     K4MK4 == *rack || K4 == *rack || LBA4 == *rack)) ||
-		     (ch1 == '4' && MK4 == *rack) || (ch1 == 's' && S2 == *rack) ||
+		     (ch1 == '4' && MK4 == *rack) ||
+		     (ch1 == 's' && S2 == *rack) ||
 		     (ch1 == 'g' && (MK4 == *rack || VLBA == *rack || VLBA4 == *rack ||
 		                     K4MK4 == *rack || LBA4 == *rack)) ||
 		     (ch1 == 'h' &&
@@ -181,7 +186,10 @@ int rlen;
 		     (ch1 == 'k' && (K4K3 == *rack || K4MK4 == *rack || K4 == *rack)) ||
 		     (ch1 == 'l' && (LBA == *rack || LBA4 == *rack)) ||
 		     (ch1 == 'd' && DBBC == *rack) || (ch1 == 'a' && 0 != *rack)) &&
-		    (ch2 == '_' || ch2 == '+' || (ch2 == 'k' && K4 == *drive1) ||
+
+		    (ch2 == '_' ||
+		     ch2 == '+' ||
+		     (ch2 == 'k' && K4 == *drive1) ||
 		     (ch2 == 'm' && MK3 == *drive1) ||
 		     (ch2 == 'n' && (MK3 == *drive1 || MK4 == *drive1)) ||
 		     (ch2 == '4' && MK4 == *drive1) || (ch2 == 's' && S2 == *drive1) ||
@@ -189,17 +197,23 @@ int rlen;
 		     (ch2 == 'a' && 0 != *drive1) ||
 		     (ch2 == 'l' &&
 		      (MK3 == *drive1 || MK4 == *drive1 || VLBA == *drive1 || VLBA4 == *drive1))) &&
-		    (ch3 == '_' || ch3 == '+' || (ch3 == 'k' && K4 == *drive2) ||
+
+		    (ch3 == '_' ||
+		     ch3 == '+' ||
+		     (ch3 == 'k' && K4 == *drive2) ||
 		     (ch3 == 'm' && MK3 == *drive2) ||
 		     (ch3 == 'n' && (MK3 == *drive2 || MK4 == *drive2)) ||
-		     (ch3 == '4' && MK4 == *drive2) || (ch3 == 's' && S2 == *drive2) ||
+		     (ch3 == '4' && MK4 == *drive2) ||
+		     (ch3 == 's' && S2 == *drive2) ||
 		     (ch3 == 'w' && (VLBA == *drive2 || VLBA4 == *drive2)) ||
 		     (ch3 == 'a' && 0 != *drive2) ||
 		     (ch3 == 'l' &&
 		      (MK3 == *drive2 || MK4 == *drive2 || VLBA == *drive2 || VLBA4 == *drive2))) &&
+
 		    ((*drive1 != 0 && *drive2 != 0 &&
 		      ((ch2 == '+' || ch3 == '+') || (ch2 == '_' && ch3 == '_'))) ||
 		     ((*drive1 == 0 || *drive2 == 0) && (ch2 != '+' && ch3 != '+')))) {
+
 			strcpy(runstr, path);
 			*ierr = 0;
 			goto cleanup;

--- a/clib/helpstr.c
+++ b/clib/helpstr.c
@@ -52,7 +52,7 @@ static char *check_help_dirs(char *name) {
 			perror("error during asprintf in check_help_dirs");
 			return NULL;
 		}
-		if (access(path, R_OK)) {
+		if (access(path, R_OK) == 0) {
 			return path;
 		}
 		free(path);

--- a/clib/helpstr.c
+++ b/clib/helpstr.c
@@ -131,7 +131,8 @@ int rlen;
 
 	*ierr = -3;
 
-	if (*clength > MAX_STRING) {
+    // one for null byte and one for potential '.'
+	if (*clength > MAX_STRING + 2) {
 		*ierr = -2;
 		return;
 	}
@@ -153,6 +154,9 @@ int rlen;
 		free(p);
 		return;
 	}
+
+	// prevent unintended prefix matches
+	strcat(name, ".");
 
 	char **paths = ls_prefix(help_dirs, name);
 	if (!paths) {

--- a/clib/helpstr.c
+++ b/clib/helpstr.c
@@ -139,6 +139,9 @@ int rlen;
 	strncpy(name, cnam, *clength);
 	name[*clength] = '\0';
 
+	// prevent directory traversal
+	if (strchr(name, '/')) return;
+
 	decloc = strchr(name, '.');
 	if (decloc != NULL) {
 		char *p = check_help_dirs(name);

--- a/fsserver/fsclient.c
+++ b/fsserver/fsclient.c
@@ -17,12 +17,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-#define _GNU_SOURCE
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <getopt.h>
+#include <limits.h>
 #include <pthread.h>
 #include <signal.h>
 #include <stdbool.h>
@@ -244,7 +244,7 @@ void handler(int sig) {
 	switch (sig) {
 	case SIGTERM:
 		fprintf(stderr, "seg fault, attempting clean shutdown...\n");
-		/* fallthrough */
+	/* fallthrough */
 	case SIGSEGV:
 	case SIGINT:
 	case SIGQUIT:
@@ -269,7 +269,7 @@ char *strsplit(char *in, char delim) {
 }
 
 void help(const char *arg) {
-	char help_file[256] = {0};
+	char help_file[PATH_MAX] = {0};
 
 	int err = 0;
 	int i   = (int)(strlen(arg));

--- a/fsserver/fsclient.c
+++ b/fsserver/fsclient.c
@@ -17,6 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+#define _GNU_SOURCE
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>


### PR DESCRIPTION
This removes the call to `system` in clib/helpstr used to list contents for fs/help and st/help starting with the user provided prefix, instead opting to list the directories directly with C routines. 

This routine is used by boss and fsclient.

This pr also removed a couple of potential buffer overruns in helpstr, although one still exist as helpstr does not check bounds of the buffer provided for output. I think this will require a signature change.

The main "business" logic was left unchanged.

It does use dynamic memory which we typically try to avoid in clib, but I have run it through valgrind and it looks like there are no leaks.


Fixes #40 