### PR TITLE
add streamlog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ quikv mcbcn brk moon logex headp fmset ibcon quikr rte_go drudg rclcn pdplt logp
 lognm pcald msg fsvue fs.prompt inject_snap erchk mk5cn tpicd flagr \
 gnfit gndat gnplt dscon systests autoftp monpcal logpl1 holog gnplt1 predict \
 dbbcn rdbcn rdtcn mk6cn popen udceth0 rack mcicn be_client s_client lgerr fesh\
-plog rdbemsg new_ifdbb dbtcn core3h_conf
+plog rdbemsg new_ifdbb streamlog dbtcn core3h_conf
 
 ifndef FS_DISPLAY_SERVER_NO_MAKE
 EXE_DIR += fsserver

--- a/streamlog/Makefile
+++ b/streamlog/Makefile
@@ -1,0 +1,5 @@
+.PHONY: all
+all: ../bin/streamlog
+
+../bin/streamlog: streamlog
+	cp $< $@

--- a/streamlog/Makefile
+++ b/streamlog/Makefile
@@ -1,5 +1,2 @@
-.PHONY: all
-all: ../bin/streamlog
-
 ../bin/streamlog: streamlog
-	cp $< $@
+	cp $^ $@

--- a/streamlog/Makefile
+++ b/streamlog/Makefile
@@ -1,2 +1,4 @@
+#
 ../bin/streamlog: streamlog
-	cp $^ $@
+	rm -f ../bin/streamlog
+	ln -s ../streamlog/streamlog ../bin/streamlog

--- a/streamlog/streamlog
+++ b/streamlog/streamlog
@@ -6,7 +6,7 @@ if [[ -n ${FS_DISPLAY_SERVER:-} ]]; then
     if ! fsserver status &> /dev/null; then echo fsserver not running; exit 1 ; fi
     if ! fsserver fs status &> /dev/null; then echo fs not running; exit 1; fi
     FS_SERVER_URL_BASE=$(awk '/FS_SERVER_URL_BASE/ {gsub(/"/, "", $3); print $3}' /usr2/fs/include/params.h)
-    exec ssub "$FS_SERVER_URL_BASE/log"
+    exec ssub -w "$FS_SERVER_URL_BASE/log"
 fi
 
 

--- a/streamlog/streamlog
+++ b/streamlog/streamlog
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Print the Field System log to stdout
+set -euo pipefail
+
+if fsserver status &> /dev/null; then
+    FS_SERVER_URL_BASE=$(awk '/FS_SERVER_URL_BASE/ {gsub(/"/, "", $3); print $3}' /usr2/fs/include/params.h)
+    exec ssub "$FS_SERVER_URL_BASE/log"
+fi
+
+
+#Kill child tail on exit
+trap 'kill $(jobs -p)' EXIT
+
+LOG=
+PID=
+
+while true; do
+    # FS isn't running or hasn't created new log yet 
+    if ! NEW=$(lognm) || [[ ! -e  "/usr2/log/${NEW}.log" ]]; then
+        sleep 1
+        continue
+    fi
+
+    if [[ "$NEW" != "$LOG" ]]; then
+
+        # Kill old tail process, disowning it so shell doesn't announce it.
+        if [[ -n "$PID" ]]; then
+            disown "$PID"
+            kill "$PID"
+        fi
+
+        # Only print the whole file it was created recently.
+        # This avoids, e.g., printing the whole stations log when switching to it.
+        if [ "$(stat --printf="%s" "/usr2/log/${NEW}.log")" -lt 4000 ]; then
+            tail -n+1 -f "/usr2/log/${NEW}.log" &
+        else
+            tail -n 0 -f "/usr2/log/${NEW}.log" &
+        fi
+        PID=$!
+        LOG=$NEW
+    fi
+    sleep 1
+done

--- a/streamlog/streamlog
+++ b/streamlog/streamlog
@@ -2,7 +2,9 @@
 # Print the Field System log to stdout
 set -euo pipefail
 
-if fsserver status &> /dev/null; then
+if [[ -z ${FS_DISPLAY_SERVER:-} ]]; then
+    if ! fsserver status > /dev/null; then echo fsserver not running; exit 1 ; fi
+    if ! fsserver fs status > /dev/null; then echo fs not running; exit 1; fi
     FS_SERVER_URL_BASE=$(awk '/FS_SERVER_URL_BASE/ {gsub(/"/, "", $3); print $3}' /usr2/fs/include/params.h)
     exec ssub "$FS_SERVER_URL_BASE/log"
 fi
@@ -15,7 +17,7 @@ LOG=
 PID=
 
 while true; do
-    # FS isn't running or hasn't created new log yet 
+    # FS isn't running or hasn't created new log yet
     if ! NEW=$(lognm) || [[ ! -e  "/usr2/log/${NEW}.log" ]]; then
         sleep 1
         continue

--- a/streamlog/streamlog
+++ b/streamlog/streamlog
@@ -2,9 +2,9 @@
 # Print the Field System log to stdout
 set -euo pipefail
 
-if [[ -z ${FS_DISPLAY_SERVER:-} ]]; then
-    if ! fsserver status > /dev/null; then echo fsserver not running; exit 1 ; fi
-    if ! fsserver fs status > /dev/null; then echo fs not running; exit 1; fi
+if [[ -n ${FS_DISPLAY_SERVER:-} ]]; then
+    if ! fsserver status &> /dev/null; then echo fsserver not running; exit 1 ; fi
+    if ! fsserver fs status &> /dev/null; then echo fs not running; exit 1; fi
     FS_SERVER_URL_BASE=$(awk '/FS_SERVER_URL_BASE/ {gsub(/"/, "", $3); print $3}' /usr2/fs/include/params.h)
     exec ssub "$FS_SERVER_URL_BASE/log"
 fi

--- a/streamlog/streamlog
+++ b/streamlog/streamlog
@@ -1,4 +1,23 @@
 #!/bin/bash
+#
+# Copyright (c) 2022 NVI, Inc.
+#
+# This file is part of VLBI Field System
+# (see http://github.com/nvi-inc/fs).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
 # Print the Field System log to stdout
 set -euo pipefail
 

--- a/streamlog/streamlog
+++ b/streamlog/streamlog
@@ -2,21 +2,60 @@
 # Print the Field System log to stdout
 set -euo pipefail
 
-if [[ -n ${FS_DISPLAY_SERVER:-} ]]; then
-    if ! fsserver status &> /dev/null; then echo fsserver not running; exit 1 ; fi
-    if ! fsserver fs status &> /dev/null; then echo fs not running; exit 1; fi
-    FS_SERVER_URL_BASE=$(awk '/FS_SERVER_URL_BASE/ {gsub(/"/, "", $3); print $3}' /usr2/fs/include/params.h)
-    exec ssub -w "$FS_SERVER_URL_BASE/log"
+usage() {
+   echo -e "\n  Usage: $(basename $0) [-h]|[-s][-w]"
+   echo -e "\n  stream FS log output\n"
+   echo "  where:"
+   echo -e "\t-h\tThis help output"
+   echo -e "\t-s\tEnable scroll-back, mostly for display server use"
+   echo -e "\t-w\tWait for FS start and restart after termination"
+   echo -e "\n  Don't use '-h' or '-w' in 'stpgm.ctl'.\n"
+}
+SCROLL=
+WAIT=
+while getopts "hws" arg; do
+    case $arg in
+        s)
+            SCROLL=-s
+            ;;
+        w)
+            WAIT=-w
+            ;;
+        h)
+            usage >&2
+            exit 0
+            ;;
+        *)
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+if [[ $# -ne 0 ]] ; then
+    usage >&2
+    exit 1
 fi
 
+if [[ -n ${FS_DISPLAY_SERVER:-} ]]; then
+    if [[ -z "$WAIT" ]]; then
+        if ! fsserver fs status &> /dev/null; then echo fs not running >&2; exit 1; fi
+    fi
+    FS_SERVER_URL_BASE=$(awk '/FS_SERVER_URL_BASE/ {gsub(/"/, "", $3); print $3}' /usr2/fs/include/params.h)
+    STRING="$WAIT $SCROLL $FS_SERVER_URL_BASE/log"
+    exec ssub $STRING
+fi
 
-#Kill child tail on exit
-trap 'kill $(jobs -p)' EXIT
 
 LOG=
 PID=
 
-while true; do
+if ! NEW=$(lognm) && [[ -z "$WAIT" ]]; then
+    echo fs not running >&2
+    exit 1
+fi
+while NEW=$(lognm) || [[ -n "$WAIT" ]]; do
     # FS isn't running or hasn't created new log yet
     if ! NEW=$(lognm) || [[ ! -e  "/usr2/log/${NEW}.log" ]]; then
         sleep 1
@@ -31,10 +70,18 @@ while true; do
             kill "$PID"
         fi
 
-        # Only print the whole file it was created recently.
-        # This avoids, e.g., printing the whole stations log when switching to it.
-        if [ "$(stat --printf="%s" "/usr2/log/${NEW}.log")" -lt 4000 ]; then
-            tail -n+1 -f "/usr2/log/${NEW}.log" &
+        #Kill child tail on exit
+        trap 'kill $(jobs -p)' EXIT
+
+        # If scroll-back is requested, print some of the log from before we
+        # started. 20 lines should be enough to get the header lines, but some
+        # extra (old) lines may appear before them and some header (and
+        # following no-header) lines may be lost if there are a lot of lines
+        # coming out quickly. This is racy, but maybe about the best we can do.
+        # The other clause is racy too, but won't print any "extra" lines; we
+        # just may lose some lines added to the new log at the transition.
+        if [ -n "$SCROLL" ]; then
+            tail -n 20 -f "/usr2/log/${NEW}.log" &
         else
             tail -n 0 -f "/usr2/log/${NEW}.log" &
         fi

--- a/streamlog/streamlog
+++ b/streamlog/streamlog
@@ -3,9 +3,10 @@
 set -euo pipefail
 
 usage() {
-   echo -e "\n  Usage: $(basename $0) [-h]|[-s][-w]"
+   echo -e "\n  Usage: $(basename $0) [-h]|[-d][-s][-w]"
    echo -e "\n  stream FS log output\n"
    echo "  where:"
+   echo -e "\t-d\tUse display stream instead of log, requires display server use"
    echo -e "\t-h\tThis help output"
    echo -e "\t-s\tEnable scroll-back, mostly for display server use"
    echo -e "\t-w\tWait for FS start and restart after termination"
@@ -13,7 +14,8 @@ usage() {
 }
 SCROLL=
 WAIT=
-while getopts "hws" arg; do
+STREAM=log
+while getopts "dhws" arg; do
     case $arg in
         s)
             SCROLL=-s
@@ -24,6 +26,13 @@ while getopts "hws" arg; do
         h)
             usage >&2
             exit 0
+            ;;
+        d)
+            if [[ ! -n ${FS_DISPLAY_SERVER:-} ]]; then
+                echo "'-d' only supported with display sever enabled" >&2
+                exit 1
+            fi
+            STREAM=windows/fs
             ;;
         *)
             usage >&2
@@ -43,7 +52,7 @@ if [[ -n ${FS_DISPLAY_SERVER:-} ]]; then
         if ! fsserver fs status &> /dev/null; then echo fs not running >&2; exit 1; fi
     fi
     FS_SERVER_URL_BASE=$(awk '/FS_SERVER_URL_BASE/ {gsub(/"/, "", $3); print $3}' /usr2/fs/include/params.h)
-    STRING="$WAIT $SCROLL $FS_SERVER_URL_BASE/log"
+    STRING="$WAIT $SCROLL $FS_SERVER_URL_BASE/$STREAM"
     exec ssub $STRING
 fi
 


### PR DESCRIPTION
This adds a utility to stream the log (and follow it as the output changes). It uses the FS server log stream if the server is enabled, otherwise falls back to `tail -f`ing the active log while polling `lognm`.

It has the advantage over a simple `tail -f /usr2/log/$(lognm).log` that it will continue to work after the FS switches to a different log. While with the FS server based method streamlog shouldn't drop messages, this isn't guaranteed for the fallback method when switching to a log that has already been written to (eg "station.log"). 

The server method could work remotely as **`ssub`** should be compilable on any modern UNIX based OS, even without the FS, and should be fairly reliable on poor networks. Otherwise, `ssh pcfs streamlog` should be fine on a reliable network.