### PR TITLE
add clang-format config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,19 @@
+---
+BasedOnStyle: LLVM
+IndentWidth: 4
+TabWidth: 4
+UseTab: ForIndentation
+DerivePointerAlignment: false
+PointerAlignment: Right
+AlignConsecutiveAssignments: true
+BreakBeforeBraces: Attach
+AlignAfterOpenBracket: Align
+AlignTrailingComments: true
+AllowShortBlocksOnASingleLine: false
+AllowShortFunctionsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false
+SpacesInParentheses: false
+SpaceBeforeParens: ControlStatements
+IndentCaseLabels: false
+ColumnLimit: 100
+---


### PR DESCRIPTION
This is a little commit to add the clang-format config, but also can serve as a discussion point for formatting in the FS code.

Currently, the code is a nasty mix of tabs and spaces — which can look terrible with if you have the wrong tabstop set — as well as a mix of styles from various decades and generations of authors. 

We've discussed adding style guides in other channels before, but to reiterate: a philosophy I've grown to appreciate from the Go community is that code is read many more times than it is written, and readability counts. 

It's much easier to parse someone else's code, or more commonly your own a few months or years later, if it follows a consistent pattern. The style minor details of the style don't really matter that much, but consistency does. Auto-formatters take some drudgery out maintaining a consistent style and, I find, also make writing code faster as you don't have to worry about some parts of style at all. Especially so if you set up your editor to format on write.

For Python code, I suggest we use [black](https://github.com/psf/black). It doesn't need any config. For Go, there's `gofmt` built into the distribution. 

This then leads to the real discussion point we need to settle. I think there're two options (though they're not mutually exclusive):

1. The bit-by-bit approach: Just format new files/code-blocks as we write them. This is kind of what I've been doing so far, and probably serve until we make a decision until we decide on the next option.
2. The change the world approach: Have one big-fat commit where we format everything and after that point everything we commit must be formatted. This might break `git blame` but [there are ways around this.](https://github.com/psf/black#migrating-your-code-style-without-ruining-git-blame)

Anyway, that's the blurb, here's the `clang-format` style. I've typically used this in new C code I've written. I'm happy to compromise on minor details (e.g. tabs for indentation or not) but the end goal is consistency. Adding this config into the root of the source tree allows `clang-format` to find and apply it. I suggest adding a plugin into your favourite editor, such as [autoformat](https://github.com/Chiel92/vim-autoformat), to run `clang-format` automatically if using approach 2., or at least use clang-format as a formatter for code blocks if using approach 1.