### PR TITLE
FSL8 no server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,11 @@ print-%  : ; @echo $* = $($*)
 #  portopen(), including ibcon.
 #
 LIB_DIR = clib flib bosslb fclib fmpsee fslb lnfch newlb polb port rtelb vis \
-poclb skdrlnfch skdrut vex rclco/rcl s2das third_party
+poclb skdrlnfch skdrut vex rclco/rcl s2das
+
+ifndef FS_NO_SERVER_MAKE
+LIB_DIR += third_party
+endif
 
 EXE_DIR = rwand chekr fserr ddout fs fsalloc incom matcn oprin pcalr onoff \
 fivpt pfmed error resid sigma xtrac boss antcn monit run labck setcl aquir \
@@ -46,7 +50,12 @@ quikv mcbcn brk moon logex headp fmset ibcon quikr rte_go drudg rclcn pdplt logp
 lognm pcald msg fsvue fs.prompt inject_snap erchk mk5cn tpicd flagr \
 gnfit gndat gnplt dscon systests autoftp monpcal logpl1 holog gnplt1 predict \
 dbbcn rdbcn rdtcn mk6cn popen udceth0 rack mcicn be_client s_client lgerr fesh\
-plog fsserver rdbemsg new_ifdbb
+plog rdbemsg new_ifdbb
+
+ifndef FS_NO_SERVER_MAKE
+LIB_DIR += fsserver
+endif
+
 
 export LDFLAGS += -L$(shell pwd)/third_party/lib
 export CPPFLAGS += -I$(shell pwd)/third_party/include

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ dbbcn rdbcn rdtcn mk6cn popen udceth0 rack mcicn be_client s_client lgerr fesh\
 plog rdbemsg new_ifdbb
 
 ifndef FS_NO_SERVER_MAKE
-LIB_DIR += fsserver
+EXE_DIR += fsserver
 endif
 
 

--- a/fs/Makefile
+++ b/fs/Makefile
@@ -7,6 +7,10 @@ ifdef NO_FTOK_FS
 CPPFLAGS :=  -DNO_FTOK_FS
 endif
 
+ifdef FS_NO_SERVER_MAKE
+CPPFLAGS +=  -DFS_NO_SERVER_MAKE
+endif
+
 LDLIBS = -lutil
 OBJECTS = fs.o statusprt.o 
 LIBS = ../flib/flib.a ../fclib/fclib.a ../clib/clib.a ../rtelb/rtelb.a

--- a/fs/fs.c
+++ b/fs/fs.c
@@ -132,7 +132,7 @@ main(int argc_in,char *argv_in[])
     if(getenv("FS_DISPLAY_SERVER") != NULL) {
         arg_no_server = false;
 #ifdef FS_NO_SERVER_MAKE
-		fprintf(stderr, "Server was not built into the FS, can't run with FS_DISPLAY_SERVER set.`\n");
+		fprintf(stderr, "Server was not built into the FS, can't run with FS_DISPLAY_SERVER set.\n");
 		exit(EXIT_FAILURE);
 #endif
     }

--- a/fs/fs.c
+++ b/fs/fs.c
@@ -131,6 +131,10 @@ main(int argc_in,char *argv_in[])
 
     if(getenv("FS_DISPLAY_SERVER") != NULL) {
         arg_no_server = false;
+#ifdef FS_NO_SERVER_MAKE
+		fprintf(stderr, "Server was not built into the FS, can't run with FS_DISPLAY_SERVER set.`\n");
+		exit(EXIT_FAILURE);
+#endif
     }
 
 	static struct option long_options[] = {


### PR DESCRIPTION
This seems like a simple solution to disable making the server on FSL8 (or others). It seems to work for FSL8/9/10.  The environment variables _FS_NO_SERVER_MAKE_ is set at compile time. This is option (1) from #76 .

There can be no use of _fsclient_ or _ssub_ in _stpgm.ctl_ or station code or scripts, but that is true if the server isn't used anyway.

@dehorsley, do you see anything I missed?

Is it worth pursuing option (2)?
