### PR TITLE
Proper fix for get_scan_source()

### DIFF
--- a/vex/vex_get.c
+++ b/vex/vex_get.c
@@ -98,10 +98,8 @@ get_scan_source(Llist *lowls_scan_in)
 
   lowls_this=lowls;
   lowls=lowls->next;
-  if(vex_version.lessthan2)
-      return ((Lowl *)lowls_this->ptr)->item;
-  else
-      return ((Source *)((Lowl *)lowls_this->ptr)->item)->key;
+
+  return ((Source *)((Lowl *)lowls_this->ptr)->item)->key;
 
 
 ldone:


### PR DESCRIPTION
The problem reported with get_scan_source() persisted despite WEH's fix.

Investigation reveals that the fix was erroneous.  What it did was to cast
the "void *" dynamically, depending on whether VEX1.5 or VEX2 was parsed, to
a different struct type and returning a different field.

The idea behind this being that in VEX2 the "source = ..." statment has
gained extra parameters compared to VEX1.5.

However, the grammar parses the "source = ..." statement into the same
struct type ("struct Source") irrespective of VEX1.5 or VEX2.

In case less than three arguments are given - e.g. in a VEX1.5 file, the
parser sets the new fields (pointing_offset, correlate) to NULL, but still
creating an instance of the same "struct Source" type.

So the fix is to cast the "void *" unconditionally to the correct struct
type and return the "->key" member, for that is the source name.