### PR TITLE
Allow plog to rename log iff not active

### DIFF
--- a/ddout/ddout.c
+++ b/ddout/ddout.c
@@ -1,4 +1,5 @@
 /*
+ck
  * Copyright (c) 2020 NVI, Inc.
  *
  * This file is part of VLBI Field System
@@ -23,6 +24,7 @@
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/file.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
@@ -348,6 +350,11 @@ Messenger:
 	}
       }
       if(fd >= 0) {
+        if(flock(fd,LOCK_EX|LOCK_NB)) {
+            perror("!! help! ** ddout");
+            fprintf(stderr,
+                    "\007!! help! ** ddout: locking log file %.8s\n",sllog);
+        }
 	memcpy(llog0, shm_addr->LLOG,8);
 	offset= lseek(fd, 0L, SEEK_END);
 	if (offset > 0) {

--- a/ddout/ddout.c
+++ b/ddout/ddout.c
@@ -1,5 +1,4 @@
 /*
-ck
  * Copyright (c) 2020 NVI, Inc.
  *
  * This file is part of VLBI Field System
@@ -24,7 +23,6 @@ ck
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <sys/file.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
@@ -350,11 +348,6 @@ Messenger:
 	}
       }
       if(fd >= 0) {
-        if(flock(fd,LOCK_EX|LOCK_NB)) {
-            perror("!! help! ** ddout");
-            fprintf(stderr,
-                    "\007!! help! ** ddout: locking log file %.8s\n",sllog);
-        }
 	memcpy(llog0, shm_addr->LLOG,8);
 	offset= lseek(fd, 0L, SEEK_END);
 	if (offset > 0) {

--- a/plog/plog
+++ b/plog/plog
@@ -20,7 +20,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-VERSION=2021-01-07
+VERSION=2021-04-05
 
 version(){
     echo "[plog $VERSION]"

--- a/plog/plog
+++ b/plog/plog
@@ -344,14 +344,6 @@ joinlst () {
     echo "$*" | sed 's/ /, /g' | sed 's/, \(\S*\)$/ or \1/g'
 }
 
-opening_process_name() {
-    local pid=$(fuser $1 2>/dev/null  | sed -e 's/^[[:space:]]*//' | head -n1)
-    if [[ -z "$pid" ]]; then
-        return
-    fi
-    ps -o comm= -p $pid
-}
-
 # Compress the log to a temp directory
 # Do not compress already compressed files
 compress() {
@@ -555,9 +547,8 @@ main () {
             logext=${log#*.} # extension, preserving .gz if it exists
             full=$FS_LOG_PATH/$ref$STATION$PLOG_FULL_SUFFIX.$logext
             if [[ $log != $full ]]; then
-                pname=$(opening_process_name $log)
-                if [[ -n $pname ]]; then
-                    fatal $log is open by $pname, aborting
+                if fuser -v $log |& grep -q " ddout$" ; then
+                    fatal "$log is open in the FS (ddout), aborting"
                 fi
                 # This should be safe, because we checked if file exists earlier. Use "-n" just in case.
                 warn file contains multicast, renaming $(basename $log) to $(basename $full)

--- a/plog/plog
+++ b/plog/plog
@@ -547,12 +547,12 @@ main () {
             logext=${log#*.} # extension, preserving .gz if it exists
             full=$FS_LOG_PATH/$ref$STATION$PLOG_FULL_SUFFIX.$logext
             if [[ $log != $full ]]; then
-                if fuser -v $log |& grep -q " ddout$" ; then
+                if fuser -v $log 2>&1 | grep -q " ddout$" ; then
                     fatal "$log is open in the FS (ddout), aborting"
                 fi
-                # This should be safe, because we checked if file exists earlier. Use "-n" just in case.
+                # This should be safe, because we checked if file exists earlier.
                 warn file contains multicast, renaming $(basename $log) to $(basename $full)
-                $DRY mv -n $log $full
+                $DRY mv $log $full
             fi
             log=$full
         fi


### PR DESCRIPTION
This uses cooperative locking to prevent _plog_ from renaming an active log if it needs to be compressed. Renaming an open log would trigger log recovery.

_ddout_ uses non-blocking locking to avoid a possible conflict if some other program has the log locked (none should). The schedule and logging must continue.

`flock()` is used, but maybe POSIX locking should be used instead if it matters.

_plog_ now also ignores if other programs (e.g.,`tail -f` or _less_) have the file open since those are benign.

Had to change `|&` to `2>&1 |` and remove `-n` for _mv_ to make it work with FSL8.

This should be squashed before merging.