### PR TITLE
Capture fsserver errors

### DIFF
--- a/fsserver/fsserver.c
+++ b/fsserver/fsserver.c
@@ -49,7 +49,7 @@ static bool opt_daemon = true;
 // error_fd is set to write end of pipe in the daemon process, which can be
 // used to send an message to the calling process if an error occurs early in
 // the startup of the daemon.
-int error_fd = -1;
+static int error_fd = -1;
 
 #define fatal(msg, s)                                                                              \
 	do {                                                                                       \

--- a/fsserver/fsserver.c
+++ b/fsserver/fsserver.c
@@ -317,7 +317,11 @@ int server_main(int argc, char *argv[]) {
 	if(asprintf(&linep,"%s/fsserver.%%Y.%%b.%%d.%%H.%%M.%%S.err",pw->pw_dir)<0)
 		fatal("making fsserver.err file format string","asprintf");
 
-	(void) strftime(fsserver_err_file,sizeof(fsserver_err_file),linep,tm);
+
+	size_t n=strftime(fsserver_err_file,sizeof(fsserver_err_file),linep,tm);
+	/* the second case is supposedly for very old, <= 4.4.1 libc, and maybe some more until 4.4.4 */
+	if(n == 0 || n>=sizeof(fsserver_err_file))
+		fatal("making fsserver.err file name","strftime");
 	free(linep);
 
 	if (opt_daemon) {

--- a/fsserver/fsserver.c
+++ b/fsserver/fsserver.c
@@ -330,7 +330,7 @@ void setup_daemon_log(char *path) {
 void setup_foreground_log(char *path) {
 	char *linep = NULL;
 	if (asprintf(&linep, "/usr/bin/tee %s", path) < 0)
-		fatal("making tee command", "asprintf");
+		fatal("making tee command", strerror(errno));
 
 	FILE *tee = popen(linep, "w");
 	if (tee == NULL)

--- a/fsserver/server.c
+++ b/fsserver/server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 NVI, Inc.
+ * Copyright (c) 2020-2021 NVI, Inc.
  *
  * This file is part of VLBI Field System
  * (see http://github.com/nvi-inc/fs).
@@ -52,6 +52,8 @@
 #include "server.h"
 #include "stream.h"
 #include "window.h"
+
+extern char fsserver_err_file[PATH_MAX];
 
 #define fatal(msg, s)                                                                              \
 	do {                                                                                       \
@@ -1088,6 +1090,10 @@ error:
 }
 
 void server_shutdown(server_t *s) {
+
+	if (unlink(fsserver_err_file))
+		fatal("unlinking fsserver.err file", strerror(errno));
+
 	nng_mtx_lock(s->mtx);
 	s->running = false;
 	if (s->finished_pipe[0] != -1) {

--- a/fsserver/server.c
+++ b/fsserver/server.c
@@ -853,7 +853,7 @@ int server_cmd(server_t *s, json_t *rep_msg, int argc, const char **const argv) 
 		return server_cmd_window(s, rep_msg, argc, argv);
 	}
 
-	if (strcmp(argv[0], "shutdown") == 0 || strcmp(argv[0], "stop") == 0)  {
+	if (strcmp(argv[0], "shutdown") == 0 || strcmp(argv[0], "stop") == 0) {
 		return server_cmd_shutdown(s, rep_msg, argc, argv);
 	}
 

--- a/fsserver/server.c
+++ b/fsserver/server.c
@@ -1091,8 +1091,15 @@ error:
 
 void server_shutdown(server_t *s) {
 
+	/* There is no point to a fatal error if the unlink fails.
+	   The server will exit anyway and if the user already
+	   deleted the file or mv'd it, it is gone. If it is just
+	   mv'd, the error will still appear there, and in the
+	   session if the server is foreground. Exiting here would
+	   also cause a 'fsserver stop' to command to not complete.
+	 */
 	if (unlink(fsserver_err_file))
-		fatal("unlinking fsserver.err file", strerror(errno));
+		perror("unlinking fsserver.err file");
 
 	nng_mtx_lock(s->mtx);
 	s->running = false;

--- a/fsserver/server.h
+++ b/fsserver/server.h
@@ -22,8 +22,8 @@
 
 typedef struct server server_t;
 
-int server_new(server_t**);
-int server_start(server_t*);
+int server_new(server_t **);
+int server_start(server_t *);
 bool server_is_running(server_t *s);
 int server_finished_fd(server_t *s);
 int server_start_fs(server_t *s);
@@ -31,3 +31,4 @@ void server_destroy(server_t *s);
 void server_shutdown(server_t *s);
 void server_sigchld_cb(server_t *s, pid_t pid, int status);
 void server_sigterm_cb(server_t *s);
+void server_set_log(server_t *s, char *log);


### PR DESCRIPTION
This is just a test of the concept. It seems to work. I have not tried to hunt down edge cases, yet. I am actually not sure where to look for those. Suggestions would be welcome. No doubt it needs some clean-up, if not complete re-writing. Since I don't completely understand the server, I may have gone off on a weird trajectory.

I tried to make it so that the file used to record the errors would be deleted if there was a clean termination (apparently that includes `SIGINT`). Whether I selected the best place to do that is not clear to me.

One thing it does not do is capture the exit code. I suppose that might be useful if, for example it gets killed by an unhandled signal. @dehorsley suggested that it might be a good idea to run the server as a service. Maybe that would capture the exit code, as well as other output and maybe without all the file descriptor machinations. If that would be _systemd_, it might be problematic for _Wheezy_ and _Lenny_ (we might not even want to think about _Etch_) since they do not use _systemd_, at least not by default. So a service might not be a universal solution in the short-term.