### PR TITLE
gnplt comment handling clean-up

### DIFF
--- a/gnplt/main.py
+++ b/gnplt/main.py
@@ -1992,11 +1992,8 @@ class Gui(Frame):
             if data[i][0] != '*':
                 data[i] = data[i].rjust(len(data[i])+1, '*')
         
-        #leave record in log
-        todays_date = time.localtime()
-        record = ['* RXG file updated by GnPlt2 on %s-%s-%s\n' % (todays_date[0], todays_date[1], todays_date[2])]
-
         #update date
+        todays_date = time.localtime()
         lineCount = 0
         for i,line in enumerate(nonComments):
             if line[0] != '*':
@@ -2005,7 +2002,7 @@ class Gui(Frame):
                 nonComments[i]='%s %s %s\n' % (todays_date[0], todays_date[1], todays_date[2])
                 break
 
-        final = record + nonComments + data
+        final = nonComments + data
         working_rxg.writelines(final)
         original_rxg.close()
         working_rxg.close()

--- a/gnplt/main.py
+++ b/gnplt/main.py
@@ -1975,7 +1975,7 @@ class Gui(Frame):
         for i,line in enumerate(data):
             if line[0] != '*':
                 stop_line = i
-        return_data = data[:i+1]
+        return_data = data[:stop_line+1]
         return return_data
     
     def copyRXGFile(self, rxg_filename):

--- a/misc/rxgfix3
+++ b/misc/rxgfix3
@@ -1,0 +1,187 @@
+#!/usr/bin/perl
+# Usage: rxgfix3 file
+
+require "getopts.pl";
+
+exit -1 if (!&Getopts("hkrt"));
+
+if (defined($opt_k) && defined($opt_r)) {
+    print "Can't use both -k and -r\n";
+    print "For help, use: $0 -h\n";
+    exit -1;
+} elsif ($#ARGV < 0 && !defined($opt_h)) {
+    print "For help, use: $0 -h\n";
+    exit -1;
+} elsif (defined($opt_h)) {
+    print "
+Usage: rxgfix3 [-hkrt] [files]
+
+  Fixes .rxg files to remove extraneous comments at the start left by
+  gnplt2. 'files' are the files to be fixed.
+
+  Any gnplt2 style leading date comments that are found before the
+  first non-comment in the file are deleted. An example of a comment
+  that would be deleted is:
+
+* RXG file updated by GnPlt2 on 2021-4-19
+
+  The date in the first such comment is extracted and compared to the
+  date on the date line (the second non-comment line). If they are
+  different, that file will be skipped. Replacing the date line with
+  the extracted date can forced with -r. Keeping the value in the date
+  line can be forced with -k.
+
+  Leading comments that do not match the date comment format will not
+  be removed.
+
+  Before making any changes, the script can be run with the options
+  -rt to see what would be changed. For the date lines that would be
+  changed, there are two options: either re-run the script with just
+  -r if the date in the comment should replace the one in the date
+  line, or use the -k option to keep the value in the date line. You
+  can apply the script to subsets of files with different options as
+  convenient.
+
+  Options:
+    -h    Print this help page.
+    -k    Keep the date in the date line if it doesn't agree with
+          the first leading comment.
+    -r    Replace the date line in file with the date in the first
+          leading comments if they don't agree.
+    -t    Test mode: show each change without updating
+
+  If a file is changed, the original is preserved with a '.bak'
+  extension.
+
+";
+    exit -1;
+
+}
+
+FILE: foreach $name (@ARGV) {
+
+    $bak = $name . ".bak";
+    $out = $name;
+    if (!-e $name) {
+	die "Can't find $name Quitting.\n";
+    }
+
+# rename the original if we can and open the files
+
+    if(!defined($opt_t)) {
+        if (-e $bak) {
+            die "Backup-file $bak already exists, giving up.\n";
+        }
+    }
+
+    if(!defined($opt_t)) {
+        rename ($out,$bak) ||die "renaming $out to $bak failed: $!, giving up.\n";
+    }
+
+    if(!defined($opt_t)) {
+        if(!open(BAK,$bak)) {
+            print "Failed to open $bak: $!\n";
+            if(!rename($bak,$out)) {
+                print "Unable to rename $bak to $out: $!\n";
+                die "Please fix whatever the problem is and rename it yourself.\n";
+            } else {
+                die "I renamed $bak to $out for you.\n";
+            }
+        }
+
+        if(!open(OUT,">" . $out)) {
+            print "Failed to open $out: $!\n";
+            if((!close(BAK)) || (!rename($bak,$out))) {
+                print "Unable to rename $bak to $out: $!\n";
+                die "Please fix whatever the problem is and rename it yourself.\n";
+            } else {
+                die "I renamed $bak to $out for you.\n";
+            }
+        }
+    } else {
+	if(!open(BAK,$out)) {
+	    die "Failed to open $out: $!\n";
+	}
+    }
+
+#process
+    $copy=0;
+    $count=0;
+    $found=0;
+    $rename=0;
+    $change=0;
+    while(<BAK>) {
+	$count++ if(/^[^*]/);
+        if($copy) {
+            print OUT if(!defined($opt_t));
+	} elsif($count == 2) {
+            if(/(\d+) +(\d+) +(\d+)/) {
+                if ($found && ($1!=$year || $2!=$month || $3!=$day)) {
+                    if(!defined($opt_k) && !defined($opt_r)) {
+                        print "Skipping $out: comment ($year $month $day) doesn't agree with date: $_";
+                        $rename=1;
+                    } elsif (defined($opt_r)) {
+                        if(defined($opt_t)) {
+                           print "$out: comment date ($year $month $day) would replace date line: $_";
+                        }
+                        $change=1;
+                        $_= "$year $month $day\n";
+                    } # else defined($opt_k), keep current line
+                }
+            } else {
+                print "Skipping $out: date line has the wrong format: $_";
+                $rename=1;
+            }
+            print OUT if(!defined($opt_t));
+            $copy=1;
+	} elsif($count == 1) {
+            print OUT if(!defined($opt_t));
+	} elsif(/^\* RXG file updated by GnPlt2 on (\d+)-(\d+)-(\d+)/) {
+            if(!$found) {
+                $year=$1;
+                $month=$2;
+                $day=$3;
+                $found=1;
+            }
+            if(defined($opt_t)) {
+                print "$out: would delete leading comment:\n$_";
+            }
+            $change=1;
+	} else {
+            print OUT if(!defined($opt_t));
+        }
+        next;
+    }
+
+    if(!defined($opt_t)) {
+        if(!close(OUT)) {
+            $rename=1;
+            print "Warning: Unable to close '$out': $!\n";
+        }
+        if(!close(BAK)) {
+            $rename=1;
+            print "Warning: Unable to close '$bak': $!\n";
+        }
+
+        if($rename || !$change) {
+            if(!rename($bak,$out)) {
+                print "Warning: Unable to rename '$bak' to '$out': $!\n";
+                if($rename) {
+                    print "Warning: Please fix whatever the problem is and rename it yourself,\n";
+                    print "Warning: probably using 'mv $bak $out'\n";
+                } else {
+                    print "Warning: It appears that $out did not need any changes,\n";
+                    print "Warning: but to be safe you should probably \"";
+                    print "Warning: use 'mv $bak $out'\n";
+                }
+            } elsif($rename) {
+                print "Warning: I renamed '$bak' to '$out' for you.\n" if($two == $one);
+
+            }
+        }
+    } else {
+	if(!close(BAK)) {
+	    print "Warning: Unable to close '$out': $!\n";
+	}
+    }
+}

--- a/misc/rxgfix3
+++ b/misc/rxgfix3
@@ -3,7 +3,7 @@
 
 require "getopts.pl";
 
-exit -1 if (!&Getopts("hkrt"));
+exit -1 if (!&Getopts("chkrt"));
 
 if (defined($opt_k) && defined($opt_r)) {
     print "Can't use both -k and -r\n";
@@ -14,7 +14,7 @@ if (defined($opt_k) && defined($opt_r)) {
     exit -1;
 } elsif (defined($opt_h)) {
     print "
-Usage: rxgfix3 [-hkrt] [files]
+Usage: rxgfix3 [-chkrt] [files]
 
   Fixes .rxg files to remove extraneous comments at the start left by
   gnplt2. 'files' are the files to be fixed.
@@ -43,6 +43,7 @@ Usage: rxgfix3 [-hkrt] [files]
   convenient.
 
   Options:
+    -c    Cut trailing comments
     -h    Print this help page.
     -k    Keep the date in the date line if it doesn't agree with
           the first leading comment.
@@ -107,11 +108,17 @@ FILE: foreach $name (@ARGV) {
 #process
     $copy=0;
     $count=0;
+    $old_count=0;
     $found=0;
     $rename=0;
     $change=0;
     while(<BAK>) {
-	$count++ if(/^[^*]/);
+	if(/^[^*]/) {
+	  $count++;
+          $trailing_comments=0;
+        } else {
+          $trailing_comments=1;
+        }
         if($copy) {
             print OUT if(!defined($opt_t));
 	} elsif($count == 2) {
@@ -150,9 +157,31 @@ FILE: foreach $name (@ARGV) {
 	} else {
             print OUT if(!defined($opt_t));
         }
+        if ($old_count != $count && !defined($opt_t)) {
+            $pos=tell OUT;
+            $old_count=$count;
+        }
         next;
     }
+#
+# handle trailing comments
+#
+    if($trailing_comments) {
+        if(defined($opt_c)) {
+            if(!defined($opt_t)) {
+                if(!$rename) {
+                    truncate OUT, $pos;
+                    $change=1;
+                }
+            } else {
+                print "$out: would delete trailing comments\n";
+            }
 
+        }
+    }
+#
+# clean-up
+#
     if(!defined($opt_t)) {
         if(!close(OUT)) {
             $rename=1;

--- a/misc/rxgfix3
+++ b/misc/rxgfix3
@@ -109,8 +109,8 @@ if ($bad_n) {
 if ($bad_b) {
     print
 "  Some back-up file(s), see messages above, already exist or couldn't
-  be deleted. Unless there an error deleting them, you can delete them
-  as part of the processing by adding the -d option.
+  be deleted. Unless there is an error deleting them, you can delete
+  them as part of the processing by adding the -d option.
 ";
 }
 if ($bad_n || $bad_b) {

--- a/misc/rxgfix3
+++ b/misc/rxgfix3
@@ -71,7 +71,7 @@ FILE: foreach $name (@ARGV) {
     $out = $name;
     if (!-e $name) {
         $bad_n=1;
-	print "Can't find $name\n";
+        print "Can't find $name\n";
     }
 
 # check for .bak file
@@ -112,7 +112,7 @@ FILE: foreach $name (@ARGV) {
     $bak = $name . ".bak";
     $out = $name;
     if (!-e $name) {
-	die "Can't find $name Quitting.\n";
+       die "Can't find $name Quitting.\n";
     }
 
 # rename the original if we can and open the files
@@ -148,12 +148,15 @@ FILE: foreach $name (@ARGV) {
             }
         }
     } else {
-	if(!open(BAK,$out)) {
-	    die "Failed to open $out: $!\n";
-	}
+        if(!open(BAK,$out)) {
+            die "Failed to open $out: $!\n";
+        }
     }
 
 #process
+    if(!defined($opt_t)) {
+        print "Processing $name\n";
+    }
     $copy=0;
     $count=0;
     $old_count=0;
@@ -161,15 +164,15 @@ FILE: foreach $name (@ARGV) {
     $rename=0;
     $change=0;
     while(<BAK>) {
-	if(/^[^*]/) {
-	  $count++;
+        if(/^[^*]/) {
+          $count++;
           $trailing_comments=0;
         } else {
           $trailing_comments=1;
         }
         if($copy) {
             print OUT if(!defined($opt_t));
-	} elsif($count == 2) {
+        } elsif($count == 2) {
             if(/(\d+) +(\d+) +(\d+)/) {
                 if ($found && ($1!=$year || $2!=$month || $3!=$day)) {
                     if(!defined($opt_k) && !defined($opt_r)) {
@@ -189,9 +192,9 @@ FILE: foreach $name (@ARGV) {
             }
             print OUT if(!defined($opt_t));
             $copy=1;
-	} elsif($count == 1) {
+        } elsif($count == 1) {
             print OUT if(!defined($opt_t));
-	} elsif(/^\* RXG file updated by GnPlt2 on (\d+)-(\d+)-(\d+)/) {
+        } elsif(/^\* RXG file updated by GnPlt2 on (\d+)-(\d+)-(\d+)/) {
             if(!$found) {
                 $year=$1;
                 $month=$2;
@@ -199,10 +202,10 @@ FILE: foreach $name (@ARGV) {
                 $found=1;
             }
             if(defined($opt_t)) {
-                print "$out: would delete leading comment:\n$_";
+                print "$out: would delete leading comment:$_";
             }
             $change=1;
-	} else {
+        } else {
             print OUT if(!defined($opt_t));
         }
         if ($old_count != $count && !defined($opt_t)) {
@@ -257,8 +260,8 @@ FILE: foreach $name (@ARGV) {
             }
         }
     } else {
-	if(!close(BAK)) {
-	    print "Warning: Unable to close '$out': $!\n";
-	}
+        if(!close(BAK)) {
+            print "Warning: Unable to close '$out': $!\n";
+        }
     }
 }

--- a/misc/rxgfix3
+++ b/misc/rxgfix3
@@ -3,7 +3,7 @@
 
 require "getopts.pl";
 
-exit -1 if (!&Getopts("chkrt"));
+exit -1 if (!&Getopts("cdhkrt"));
 
 if (defined($opt_k) && defined($opt_r)) {
     print "Can't use both -k and -r\n";
@@ -14,7 +14,7 @@ if (defined($opt_k) && defined($opt_r)) {
     exit -1;
 } elsif (defined($opt_h)) {
     print "
-Usage: rxgfix3 [-chkrt] [files]
+Usage: rxgfix3 [-cdhkrt] [files]
 
   Fixes .rxg files to remove extraneous comments at the start left by
   gnplt2. 'files' are the files to be fixed.
@@ -42,8 +42,14 @@ Usage: rxgfix3 [-chkrt] [files]
   can apply the script to subsets of files with different options as
   convenient.
 
+  If any of the files don't exist or there is have .bak version
+  already, the script will give up before doing any processing. The -d
+  option can be used to delete all matching .bak files before
+  procesing.
+
   Options:
     -c    Cut trailing comments
+    -d    Delete old back-up files at start
     -h    Print this help page.
     -k    Keep the date in the date line if it doesn't agree with
           the first leading comment.
@@ -57,6 +63,48 @@ Usage: rxgfix3 [-chkrt] [files]
 ";
     exit -1;
 
+}
+
+FILE: foreach $name (@ARGV) {
+
+    $bak = $name . ".bak";
+    $out = $name;
+    if (!-e $name) {
+        $bad_n=1;
+	print "Can't find $name\n";
+    }
+
+# check for .bak file
+
+    if (-e $bak) {
+        if(!defined($opt_t)) {
+            if (!defined($opt_d)) {
+                $bad_b=1;
+                print "Backup file $bak already exists.\n";
+            } elsif (!unlink($bak)){
+                $bad_b=1;
+                print "Deleting $bak failed: $!.\n";
+            } else {
+                print "Deleted $bak\n";
+            }
+        } else {
+            if (!defined($opt_d)) {
+                print "Backup file $bak already exists, which would block processing.\n";
+            } else {
+                print "Existing back-up file $bak: would be deleted\n";
+            }
+        }
+    }
+}
+if ($bad_n) {
+    print "  Couldn't find some specified file(s).\n";
+}
+if ($bad_b) {
+    print "  Some back-up file(s) already exist, delete or rename them.\n";
+    print "  You can delete them as part of the processing by adding the -d option.\n";
+}
+if ($bad_n || $bad_b) {
+    die "Giving up.\n";
 }
 
 FILE: foreach $name (@ARGV) {

--- a/misc/rxgfix3
+++ b/misc/rxgfix3
@@ -89,19 +89,22 @@ FILE: foreach $name (@ARGV) {
             }
         } else {
             if (!defined($opt_d)) {
-                print "Backup file $bak already exists, which would block processing.\n";
+                print "Backup file $bak already exists, which blocks processing.\n";
             } else {
-                print "Existing back-up file $bak: would be deleted\n";
+                print "Delete existing back-up file $bak\n";
             }
         }
     }
 }
 if ($bad_n) {
-    print "  Couldn't find some specified file(s).\n";
+    print "  Couldn't find file(s) listed above.\n";
 }
 if ($bad_b) {
-    print "  Some back-up file(s) already exist, delete or rename them.\n";
-    print "  You can delete them as part of the processing by adding the -d option.\n";
+    print
+"  Some back-up file(s), see messages above, already exist or couldn't
+  be deleted. Unless there an error deleting them, you can delete them
+  as part of the processing by adding the -d option.
+";
 }
 if ($bad_n || $bad_b) {
     die "Giving up.\n";
@@ -180,7 +183,7 @@ FILE: foreach $name (@ARGV) {
                         $rename=1;
                     } elsif (defined($opt_r)) {
                         if(defined($opt_t)) {
-                           print "$out: comment date ($year $month $day) would replace date line: $_";
+                           print "$out: use comment date ($year $month $day) to replace date line: $_";
                         }
                         $change=1;
                         $_= "$year $month $day\n";
@@ -202,7 +205,7 @@ FILE: foreach $name (@ARGV) {
                 $found=1;
             }
             if(defined($opt_t)) {
-                print "$out: would delete leading comment:$_";
+                print "$out: delete leading comment: $_";
             }
             $change=1;
         } else {
@@ -217,17 +220,14 @@ FILE: foreach $name (@ARGV) {
 #
 # handle trailing comments
 #
-    if($trailing_comments) {
-        if(defined($opt_c)) {
-            if(!defined($opt_t)) {
-                if(!$rename) {
-                    truncate OUT, $pos;
-                    $change=1;
-                }
-            } else {
-                print "$out: would delete trailing comments\n";
+    if($trailing_comments && defined($opt_c)) {
+        if(!defined($opt_t)) {
+            if(!$rename) {
+                truncate OUT, $pos;
+                $change=1;
             }
-
+        } else {
+            print "$out: delete trailing comments\n";
         }
     }
 #

--- a/misc/rxgfix3
+++ b/misc/rxgfix3
@@ -42,10 +42,17 @@ Usage: rxgfix3 [-cdhkrt] [files]
   can apply the script to subsets of files with different options as
   convenient.
 
+  The -c option will remove all trailing comments. This can be useful
+  to remove a trailing comment history that has gotten out of order.
+  That will make it easier to clean-up the trailing comments later, if
+  that is desired. A backup should be made before using this option.
+  The backup can be used as a basis for cleaning-up the comments or as
+  an archive.
+
   If any of the files don't exist or there is have .bak version
   already, the script will give up before doing any processing. The -d
   option can be used to delete all matching .bak files before
-  procesing.
+  processing.
 
   Options:
     -c    Cut trailing comments


### PR DESCRIPTION
This PR started out as an answer to issue #111 (which has more discussion).  It covers three _gnplt_ comment related changes:

- Not double copying trailing comments in the .rxg files when updating.
- Not adding a _leading_ `RXG file updated by GnPlt2` date comment. It is no longer needed now that the date line is being updated.
- A script, _rxgfix3_, to help clean-up the _leading_ `GnPlt2` date comments that were added by _gnplt_.
