### PR TITLE
shutdown fsserver on fs terminate

### DIFF
--- a/boss/bwork.f
+++ b/boss/bwork.f
@@ -91,6 +91,7 @@ C     NCPARM - # chars in procedure parameter string
       character*12 setup_proc
       integer trimlen
       logical krcur,klast,kts,kskblk,kopblk,kbreak,kstak,kon
+      character*256 display_server_envar
 C                   KRCUR returns true if a procedure calls itself
 C                   KPAST returns true if a given time is earlier than now
 C                   KLAST true if this is last time scheduling of command
@@ -853,23 +854,29 @@ C
            if(disk_record_record.eq.1) then
               call logit7ci(0,0,0,0,-173,'bo',0)
            endif
-           ipida=fc_find_process('autoftp'//char(0),ierr)
-           if(ipida.ge.0) then
-              call logit7ci(0,0,0,0,-174,'bo',0)
-           else if(ipida.gt.-7) then
-              if(ipida.gt.-5) then
-                 call logit7ci(0,0,0,0,ierr,'un',0)
+           call getenv('FS_DISPLAY_SERVER', display_server_envar)
+           if (display_server_envar == "on") then
+              ipida=fc_find_process('autoftp'//char(0),ierr)
+              if(ipida.ge.0) then
+                 call logit7ci(0,0,0,0,-174,'bo',0)
+              else if(ipida.gt.-7) then
+                 if(ipida.gt.-5) then
+                    call logit7ci(0,0,0,0,ierr,'un',0)
+                 endif
+                 call logit7ci(0,0,0,1,-177,'bo',ipida)
               endif
-              call logit7ci(0,0,0,1,-177,'bo',ipida)
-           endif
-           ipidf=fc_find_process('fs.prompt'//char(0),ierr)
-           if(ipidf.ge.0) then
-              call logit7ci(0,0,0,0,-175,'bo',0)
-           else if(ipidf.gt.-7) then
-              if(ipidf.gt.-5) then
-                 call logit7ci(0,0,0,0,ierr,'un',0)
-              endif
-              call logit7ci(0,0,0,1,-178,'bo',ipidf)
+              ipidf=fc_find_process('fs.prompt'//char(0),ierr)
+              if(ipidf.ge.0) then
+                 call logit7ci(0,0,0,0,-175,'bo',0)
+              else if(ipidf.gt.-7) then
+                 if(ipidf.gt.-5) then
+                    call logit7ci(0,0,0,0,ierr,'un',0)
+                 endif
+                 call logit7ci(0,0,0,1,-178,'bo',ipidf)
+               endif
+           else
+              ipida=-7
+              ipidf=-7
            endif
            if(disk_record_record.eq.1.or.
      &        ipida.ne.-7.or.ipidf.ne.-7) then

--- a/boss/bwork.f
+++ b/boss/bwork.f
@@ -66,6 +66,7 @@ C                         Ref times for operator and schedule streams
       equivalence (lnamef,cnamef),(tmpchr,tmpstr)
       character*28 pathname
       integer idcbp1(2),idcbp2(2),fc_system,fc_skd_end_insnp,fc_if_cmd
+      integer fc_find_process
       save idcbp1,idcbp2
 C                         DCB's for procedures from lists 1 and 2
       dimension istksk(42),istkop(42)        !  stacks for nested procedures
@@ -838,7 +839,7 @@ C
         nchar = min0(ireg(2),iblen*2)
         ich = 1+iscn_ch(ibuf,1,nchar,'=')
         if (ich.ne.1) then
-           if(ichcm_ch(ibuf,ich,'disk_record_ok').ne.0) then
+           if(ichcm_ch(ibuf,ich,'force').ne.0) then
               call logit7ci(0,0,0,0,-172,'bo',0)
               if(iwait.ne.0) then
                  ipinsnp(3)=-172
@@ -851,8 +852,30 @@ C
            call fs_get_disk_record_record(disk_record_record)
            if(disk_record_record.eq.1) then
               call logit7ci(0,0,0,0,-173,'bo',0)
+           endif
+           ipida=fc_find_process('autoftp'//char(0),ierr)
+           if(ipida.ge.0) then
+              call logit7ci(0,0,0,0,-174,'bo',0)
+           else if(ipida.gt.-7) then
+              if(ipida.gt.-5) then
+                 call logit7ci(0,0,0,0,ierr,'un',0)
+              endif
+              call logit7ci(0,0,0,1,-177,'bo',ipida)
+           endif
+           ipidf=fc_find_process('fs.prompt'//char(0),ierr)
+           if(ipidf.ge.0) then
+              call logit7ci(0,0,0,0,-175,'bo',0)
+           else if(ipidf.gt.-7) then
+              if(ipidf.gt.-5) then
+                 call logit7ci(0,0,0,0,ierr,'un',0)
+              endif
+              call logit7ci(0,0,0,1,-178,'bo',ipidf)
+           endif
+           if(disk_record_record.eq.1.or.
+     &        ipida.ne.-7.or.ipidf.ne.-7) then
+              call logit7ci(0,0,0,0,-176,'bo',0)
               if(iwait.ne.0) then
-                 ipinsnp(3)=-173
+                 ipinsnp(3)=-176
                  call char2hol('bo',ipinsnp(4),1,2)
                  ipinsnp(5)=0
               endif

--- a/boss/bwork.f
+++ b/boss/bwork.f
@@ -837,6 +837,15 @@ C
       else if (mbranch.eq.10) then
          ierr=0
         ireg(2) = get_buf(iclass,ibuf,-iblen*2,idum,idum)
+        if (rn_test('pfmed')) then
+          call logit7ci(0,0,0,0,-171,'bo',0)
+          if(iwait.ne.0) then
+             ipinsnp(3)=-171
+             call char2hol('bo',ipinsnp(4),1,2)
+             ipinsnp(5)=0
+          endif
+          goto 600
+        endif
         nchar = min0(ireg(2),iblen*2)
         ich = 1+iscn_ch(ibuf,1,nchar,'=')
         if (ich.ne.1) then
@@ -888,15 +897,6 @@ C
               endif
               goto 600
            endif
-        endif
-        if (rn_test('pfmed')) then
-          call logit7ci(0,0,0,0,-171,'bo',0)
-          if(iwait.ne.0) then
-             ipinsnp(3)=-171
-             call char2hol('bo',ipinsnp(4),1,2)
-             ipinsnp(5)=0
-          endif
-          goto 600
         endif
         do i=1,20
           icheck(i)=0

--- a/clib/Makefile
+++ b/clib/Makefile
@@ -48,7 +48,7 @@ trkfrm_util.o user_device_util.o user_info_util.o v2_head_vmov.o \
 v2_motion_done.o v2_vlt_head.o v_vlt_head.o vacuum.o venable_util.o vform_util.o \
 vlbabbcd.o vrepro_util.o vset_zero.o vsi4_util.o vst_util.o wvolt_util.o \
 caccess.o get_gain_rxg.o log_rxgfile.o dbbc3_core3h_modex_util.o \
-dbbc3_version_check.o mk5dbbc3d.o get_dbbc3time.o
+dbbc3_version_check.o mk5dbbc3d.o get_dbbc3time.o find_process.o
 
 clib.a: $(OBJECTS)
 

--- a/clib/find_process.c
+++ b/clib/find_process.c
@@ -82,6 +82,8 @@ pid_t find_process(const char* name,int *err)
                 return (pid_t) ipid;
             } else
                 fclose(fp);
+        } else if (ENOENT==errno) {
+          continue; /* in case the file disappeared after the directory read */
         } else {
             closedir(dir);
             *err=errno;

--- a/clib/find_process.c
+++ b/clib/find_process.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2022 NVI, Inc.
+ *
+ * This file is part of VLBI Field System
+ * (see http://github.com/nvi-inc/fs).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <sys/types.h>
+#include <dirent.h>
+#include<unistd.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <errno.h>
+
+pid_t find_process(const char* name,int *err)
+{
+// Return values:
+//     +ve = pid of a process with program 'name'
+//      0  = not possible
+//     -1  = can't open /proc
+//     -2  = error reading /proc
+//     -3  = can't open /proc/PID/stat
+//     -4  = can't read /proc/PID/stat
+//     -5  = can't decode /proc/PID/stat
+//     -6  = can't form file name
+//     -7  = 'name' not active
+//
+// -1 to -4 set *err with errno
+
+    DIR* dir;
+    struct dirent* ent;
+    char buf[512];
+
+    long  pid;
+    char pname[33] = {0,}; /* actual maximum is 16 plus a null */
+    char state;
+    FILE *fp=NULL;
+    int ipid;
+    int count;
+
+    if (!(dir = opendir("/proc"))) {
+        *err = errno;
+        return -1;
+    }
+
+    errno=0;
+    while (NULL != (ent = readdir(dir))) {
+        if (0 >= (ipid = atoi(ent->d_name)))
+            continue;
+        if (sizeof(buf) <= snprintf(buf, sizeof(buf), "/proc/%d/stat", ipid)) {
+            closedir(dir);
+            return -6;
+        }
+        fp = fopen(buf, "r");
+        if (fp) {
+            if (EOF == (count = fscanf(fp, "%d (%32[^)]) %c", &pid, pname, &state))) {
+                fclose(fp);
+                closedir(dir);
+                return -4;
+            } else if (3 != count) {
+                fclose(fp);
+                closedir(dir);
+                return -5;
+            } else if (!strcmp(pname, name)) {
+                fclose(fp);
+                closedir(dir);
+                return (pid_t) ipid;
+            } else
+                fclose(fp);
+        } else {
+            closedir(dir);
+            *err=errno;
+            return -3;
+        }
+        errno=0;
+    }
+
+    if(errno) {
+        *err=errno;
+        return -2;
+    } else {
+        closedir(dir);
+        return -7;
+    }
+}

--- a/control/fserr.ctl
+++ b/control/fserr.ctl
@@ -1263,10 +1263,25 @@ BO -171
 Resource locked. Cannot terminate. Is PFMED running?
 ""
 BO -172
-Parameter for terminate must be disk_record_ok.
+Parameter for terminate must be 'force'.
 ""
 BO -173
-Don't terminate while recording, either use disk_record=off first or (dangerous) terminate=disk_record_ok.
+Can't terminate while recording, use disk_record=off first.
+""
+BO -174
+Can't terminate while autoftp is active, wait for all instances to finish first
+""
+BO -175
+Can't terminate while fs.prompt is active, close all instances first.
+""
+BO -176
+One or more conditions above is preventing termination, if you must terminate (dangerous) use terminate=force.
+""
+BO -177
+Can't terminate due to internal error?WW checking autoftp status, report this and the above 'un' error.
+""
+BO -178
+Can't terminate due to internal error?WW checking fs.prompt status, report this and the above 'un' error.
 ""
 BO -180
 Error opening TIME.CTL, UNIX ?FFF

--- a/fclib/Makefile
+++ b/fclib/Makefile
@@ -21,7 +21,8 @@ fc_rte_ticks.o fc_readlink.o fc_perror.o fc_mk5vcd.o fc_mk5bbcd.o\
 fc_get_5btime.o fc_play_wav.o fc_rte_check.o fc_putln2.o fc_mk5dbbcd.o\
 fc_tpi_dbbc.o fc_dbbcn_v.o fc_get_fila10gtime.o fc_antcn_term.o\
 fc_mk5dbbcd_pfb.o fc_tpi_dbbc_pfb.o fc_dbbcn_pfb_v.o fc_if_cmd.o\
-fc_rdbcn_v.o fc_dbbc3n_v.o fc_tpi_dbbc3.o fc_access.o fc_get_dbbc3time.o
+fc_rdbcn_v.o fc_dbbc3n_v.o fc_tpi_dbbc3.o fc_access.o fc_get_dbbc3time.o\
+fc_find_process.o
 fclib.a: $(OBJECTS)
 
 include ../include.mk

--- a/fclib/fc_find_process.c
+++ b/fclib/fc_find_process.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022 NVI, Inc.
+ *
+ * This file is part of VLBI Field System
+ * (see http://github.com/nvi-inc/fs).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <sys/types.h>
+
+pid_t find_process();
+
+int fc_find_process__( name, err, nlen)
+char *name;
+int *err, nlen;
+{
+    return find_process(name,err);
+}

--- a/fsserver/server.c
+++ b/fsserver/server.c
@@ -994,6 +994,7 @@ void server_sigchld_cb(server_t *s, pid_t pid, int status) {
 		s->fs->status = status;
 		s->fs->pid    = 0;
 		nng_mtx_unlock(s->mtx);
+		server_shutdown(s);
 		return;
 	}
 	window_t *w = list_pop(&s->windows, window_by_pid, &pid);

--- a/help/terminate.___
+++ b/help/terminate.___
@@ -6,7 +6,7 @@
             Response:   none
 
 
-Settabel Parameters:
+Settable Parameters:
        force           literal text: force
 
 Comments: 
@@ -14,18 +14,28 @@ This is the graceful way to end operation of the Field System.
 Schedule execution is ended, log and schedule files are closed, all
 online FS programs are removed from the system.
 
-The 'terminate' command will not succeed if: (i) recording has been
-commanded with the 'disk_record=on', (ii) an instance of 'autoftp' is
-active, (iii) an instance of 'fs.prompt' is active, or (iv) 'pfmed' is
-active.
+There are four conditions that can stop 'terminate' from succeeding.
+The first two are:
 
-If it is appropriate to do so, the first three conditions can be
-corrected by: (i) stopping recording with 'disk_record=off', (ii)
-waiting for all instances of 'autoftp' to finish, or (iii) closing all
-instances of 'fs.prompt'. Alternately, 'terminate=force' can override
-the first three conditions and force termination immediately, but this
+ (i) 'pfmed' being active
+(ii) recording having been commanded with 'disk_record=on'
+
+If the display server is in use, termination will also be blocked if:
+
+(iii) any instances of 'autoftp' are active
+ (iv) any instances of 'fs.prompt' are active
+
+If it is appropriate, the four conditions can be corrected by:
+
+  (i) exiting 'pfmed'
+ (ii) using 'disk_record=off' to stop recording
+(iii) waiting for all instances of 'autoftp' to finish
+ (iv) closing all instances of 'fs.prompt'
+
+Alternately, if it is necessary to terminate immediately, the last
+three conditions can be overridden with 'terminate=force', but this
 may cause other problems related to the conditions that were
-preventing termination.
+preventing termination. The user should be careful.
 
-There is no way to override 'pfmed' being active stopping termination.
-To correct that condition, exit that utility.
+There is no way to override the condition for 'pfmed' being active;
+the program must be exited.

--- a/help/terminate.___
+++ b/help/terminate.___
@@ -1,22 +1,31 @@
               terminate - end field system operation
 
             Syntax:     terminate
-                        terminate=okay
+                        terminate=force
 
             Response:   none
 
 
 Settabel Parameters:
-       okay            literal ascii: disk_record_ok
+       force           literal text: force
 
 Comments: 
 This is the graceful way to end operation of the Field System.
-Schedule execution is ended, log and schedule files are
-closed, all programs are removed from the system by oprin.
+Schedule execution is ended, log and schedule files are closed, all
+online FS programs are removed from the system.
 
-The terminate command will not succeed if recording has been commanded
-with the disk_record=on command.  Either recording must be stopped
-using disk_record=off first or if you wish to continue recording
-despite terminating the FS, you can use
-"terminate=disk_record_ok".  Terminating the FS while the disk is
-recording is not recommended.
+The 'terminate' command will not succeed if: (i) recording has been
+commanded with the 'disk_record=on', (ii) an instance of 'autoftp' is
+active, (iii) an instance of 'fs.prompt' is active, or (iv) 'pfmed' is
+active.
+
+If it is appropriate to do so, the first three conditions can be
+corrected by: (i) stopping recording with 'disk_record=off', (ii)
+waiting for all instances of 'autoftp' to finish, or (iii) closing all
+instances of 'fs.prompt'. Alternately, 'terminate=force' can override
+the first three conditions and force termination immediately, but this
+may cause other problems related to the conditions that were
+preventing termination.
+
+There is no way to override 'pfmed' being active stopping termination.
+To correct that condition, exit that utility.

--- a/help/terminate.___
+++ b/help/terminate.___
@@ -38,4 +38,6 @@ may cause other problems related to the conditions that were
 preventing termination. The user should be careful.
 
 There is no way to override the condition for 'pfmed' being active;
-the program must be exited.
+the program must be exited. This condition is checked before the
+others since there is no point using 'force' if 'pfmed' is going to
+block termination anyway.


### PR DESCRIPTION
This commit (re)adds the feature that **`fsserver`** gracefully shuts down when the child `fs` process terminates. During the shutdown, all child FS windows will be killed.

I've done some basic testing, and it should do what it says on the tin, but I haven't fully thought through the consequences.