### PR TITLE
fix incorrect pipe ends in fsserver

### DIFF
--- a/fsserver/server.c
+++ b/fsserver/server.c
@@ -330,8 +330,8 @@ int server_finished_fd(server_t *s) {
 		s->finished_pipe[1] = -1;
 		return -1;
 	}
-	fcntl(s->finished_pipe[0], F_SETFD, FD_CLOEXEC);
-	int r = s->finished_pipe[1];
+	fcntl(s->finished_pipe[1], F_SETFD, FD_CLOEXEC);
+	int r = s->finished_pipe[0];
 	nng_mtx_unlock(s->mtx);
 	return r;
 }
@@ -1093,7 +1093,7 @@ void server_shutdown(server_t *s) {
 	nng_mtx_lock(s->mtx);
 	s->running = false;
 	if (s->finished_pipe[0] != -1) {
-		close(s->finished_pipe[0]);
+		close(s->finished_pipe[1]);
 		s->finished_pipe[0] = -1;
 		s->finished_pipe[1] = -1;
 	}


### PR DESCRIPTION
The main thread of fsserver uses a pselect loop pickup unix signals
handle them gracefully. This is need because the server uses
locks, and it's not a good idea to try acquiring locks inside signal
handlers! To ensure the pselect is unblocked when the server needs
to shutdown, the server maintains a pipe the write end of which is
closed when the server is ready to shutdown, and the read end can be
given to the pselect call. When the pipe is closed, the pselect will
break and the main thread cleans up the server structure and close the
connections then ends.

At least that's how it was meant to work. Previously the write end
was being fed to pselect. This fixes that.

It's a bit of a puzzle why that actually works. I guess when it works,
the pselect call is coincidentally getting interrupted due to a signal,
probably SIGCHLD, and sees the server has entered shutdown. This could
explain issue #178.

Credit to @wehimwich for spotting it!