### PR TITLE
Add wait to let previous fsserver shutdown

### DIFF
--- a/fsalloc/fsalloc.c
+++ b/fsalloc/fsalloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 NVI, Inc.
+ * Copyright (c) 2020, 2023 NVI, Inc.
  *
  * This file is part of VLBI Field System
  * (see http://github.com/nvi-inc/fs).
@@ -64,6 +64,7 @@ main()
 				       &shm_addr->time.ticks_off,
 				       &shm_addr->time.init_error,
 				       &shm_addr->time.init_errno);
+    shm_addr->terminate_ticks=0;
     key = SEM_KEY;
     nsems = SEM_NUM;
     if( (sem_id = sem_get( key, nsems)) == -1) {

--- a/fsserver/fsclient.c
+++ b/fsserver/fsclient.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 NVI, Inc.
+ * Copyright (c) 2020, 2023 NVI, Inc.
  *
  * This file is part of VLBI Field System
  * (see http://github.com/nvi-inc/fs).
@@ -433,6 +433,7 @@ void fetch_state(void) {
 	}
 
 	if ((rv = nng_dial(server_cmd_sock, server_cmd_url, NULL, 0)) != 0) {
+                fprintf(stderr,"If you restarted the FS, fsserver may have needed more time to cleanup. Try again.\n");
 		fatal("unable to connect to server", nng_strerror(rv));
 	}
 

--- a/include/fscom.h
+++ b/include/fscom.h
@@ -542,4 +542,6 @@ typedef struct fscom {
   int  dbbc3_ddce_v;
   char dbbc3_ddce_vs[16];
   int  dbbc3_ddce_vc;
+
+  int terminate_ticks;
 } Fscom;


### PR DESCRIPTION
* Give it at least two seconds.
* Expand fsclient error message to explain if there still wasn't enough time.

This is a but brute force, but the needed code is probably rarely triggered.

This is cleanup for #176